### PR TITLE
Removed JsonAny from message signatures

### DIFF
--- a/packages/vscode-messenger-common/src/messages.ts
+++ b/packages/vscode-messenger-common/src/messages.ts
@@ -113,7 +113,7 @@ export type JsonArray = JsonAny[];
  * Data structure for defining a request type.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type RequestType<P extends JsonAny, R> = { method: string };
+export type RequestType<P, R> = { method: string };
 
 /**
  * Function for handling incoming requests.
@@ -125,7 +125,7 @@ export type HandlerResult<R> = R | Promise<R>;
  * Data structure for defining a notification type.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type NotificationType<P extends JsonAny> = { method: string };
+export type NotificationType<P> = { method: string };
 
 /**
  * Function for handling incoming notifications.
@@ -136,8 +136,8 @@ export type NotificationHandler<P> = (params: P) => void | Promise<void>;
  * Base API for Messenger implementations.
  */
 export interface MessengerAPI {
-    sendRequest<P extends JsonAny, R>(type: RequestType<P, R>, receiver: MessageParticipant, params: P): Promise<R>
-    onRequest<P extends JsonAny, R>(type: RequestType<P, R>, handler: RequestHandler<P, R>): void
-    sendNotification<P extends JsonAny>(type: NotificationType<P>, receiver: MessageParticipant, params: P): void
-    onNotification<P extends JsonAny>(type: NotificationType<P>, handler: NotificationHandler<P>): void
+    sendRequest<P, R>(type: RequestType<P, R>, receiver: MessageParticipant, params: P): Promise<R>
+    onRequest<P, R>(type: RequestType<P, R>, handler: RequestHandler<P, R>): void
+    sendNotification<P>(type: NotificationType<P>, receiver: MessageParticipant, params: P): void
+    onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): void
 }

--- a/packages/vscode-messenger-webview/src/messenger.ts
+++ b/packages/vscode-messenger-webview/src/messenger.ts
@@ -28,12 +28,12 @@ export class Messenger implements MessengerAPI {
         this.options = { ...defaultOptions, ...options };
     }
 
-    onRequest<P extends JsonAny, R>(type: RequestType<P, R>, handler: RequestHandler<P, R>): Messenger {
+    onRequest<P, R>(type: RequestType<P, R>, handler: RequestHandler<P, R>): Messenger {
         this.handlerRegistry.set(type.method, handler as RequestHandler<unknown, unknown>);
         return this;
     }
 
-    onNotification<P extends JsonAny>(type: NotificationType<P>, handler: NotificationHandler<P>): Messenger {
+    onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Messenger {
         this.handlerRegistry.set(type.method, handler as NotificationHandler<unknown>);
         return this;
     }
@@ -119,7 +119,7 @@ export class Messenger implements MessengerAPI {
         }
     }
 
-    sendRequest<P extends JsonAny, R>(type: RequestType<P, R>, receiver: MessageParticipant, params: P): Promise<R> {
+    sendRequest<P, R>(type: RequestType<P, R>, receiver: MessageParticipant, params: P): Promise<R> {
         if (receiver.type === 'broadcast') {
             throw new Error('Only notification messages are allowed for broadcast.');
         }
@@ -132,17 +132,19 @@ export class Messenger implements MessengerAPI {
             id: msgId,
             method: type.method,
             receiver,
-            params
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            params: params as any
         };
         this.vscode.postMessage(message);
         return result;
     }
 
-    sendNotification<P extends JsonAny>(type: NotificationType<P>, receiver: MessageParticipant, params: P): void {
+    sendNotification<P>(type: NotificationType<P>, receiver: MessageParticipant, params: P): void {
         const message: NotificationMessage = {
             method: type.method,
             receiver,
-            params
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            params: params as any
         };
         this.vscode.postMessage(message);
     }


### PR DESCRIPTION
With the published version 0.2.0, I get an error with the following code:
```typescript
export interface SprottyDiagramIdentifier {
    clientId: string,
    diagramType: string,
    uri: string
}

export const DiagramIdentifierNotification: NotificationType<SprottyDiagramIdentifier> = { method: 'SprottyDiagramIdentifier' };
```

Error:
```
Type 'SprottyDiagramIdentifier' does not satisfy the constraint 'JsonAny'.
  Type 'SprottyDiagramIdentifier' is not assignable to type 'JsonMap'.
    Index signature for type 'string' is missing in type 'SprottyDiagramIdentifier'. ts(2344)
```

This change should fix that. The motivation behind JsonAny was to enforce the objects to be JSON-serializeable, but obviously this not easily possible.