### PR TITLE
fix: use empty cancellation `reason` as default

### DIFF
--- a/packages/vscode-messenger-common/src/cancellation.ts
+++ b/packages/vscode-messenger-common/src/cancellation.ts
@@ -26,9 +26,9 @@ export class Deferred<R = any> {
 */
 export class CancellationTokenImpl implements CancellationToken {
     private canceled = false;
-    private listeners: Array<((reason: string) => void)> = [];
+    private listeners: Array<((reason?: string) => void)> = [];
 
-    public cancel(reason = ''): void {
+    public cancel(reason?: string): void {
         if (this.canceled) {
             throw new Error('Request was already canceled.');
         }
@@ -41,7 +41,7 @@ export class CancellationTokenImpl implements CancellationToken {
         return this.canceled;
     }
 
-    public onCancellationRequested(callback: (reason: string) => void): Disposable {
+    public onCancellationRequested(callback: (reason?: string) => void): Disposable {
         this.listeners.push(callback);
         const listeners = this.listeners;
         return {

--- a/packages/vscode-messenger-common/src/cancellation.ts
+++ b/packages/vscode-messenger-common/src/cancellation.ts
@@ -22,18 +22,18 @@ export class Deferred<R = any> {
 
 /**
 * Implementation of the CancellationToken interface.
-* Allows to trigger cancelation.
+* Allows to trigger cancellation.
 */
 export class CancellationTokenImpl implements CancellationToken {
     private canceled = false;
     private listeners: Array<((reason: string) => void)> = [];
 
-    public cancel(reason: string): void {
+    public cancel(reason: string = ''): void {
         if (this.canceled) {
             throw new Error('Request was already canceled.');
         }
         this.canceled = true;
-        this.listeners.forEach(callBack => callBack(reason));
+        this.listeners.forEach(callback => callback(reason));
         this.listeners = [];
     }
 
@@ -41,12 +41,12 @@ export class CancellationTokenImpl implements CancellationToken {
         return this.canceled;
     }
 
-    public onCancellationRequested(callBack: (reason: string) => void): Disposable {
-        this.listeners.push(callBack);
+    public onCancellationRequested(callback: (reason: string) => void): Disposable {
+        this.listeners.push(callback);
         const listeners = this.listeners;
         return {
             dispose() {
-                listeners.splice(listeners.indexOf(callBack), 1);
+                listeners.splice(listeners.indexOf(callback), 1);
             }
         };
     }

--- a/packages/vscode-messenger-common/src/cancellation.ts
+++ b/packages/vscode-messenger-common/src/cancellation.ts
@@ -28,7 +28,7 @@ export class CancellationTokenImpl implements CancellationToken {
     private canceled = false;
     private listeners: Array<((reason: string) => void)> = [];
 
-    public cancel(reason: string = ''): void {
+    public cancel(reason = ''): void {
         if (this.canceled) {
             throw new Error('Request was already canceled.');
         }

--- a/packages/vscode-messenger-common/src/messages.ts
+++ b/packages/vscode-messenger-common/src/messages.ts
@@ -188,7 +188,7 @@ export interface MessengerAPI {
  */
 export interface CancellationToken {
     readonly isCancellationRequested: boolean;
-    onCancellationRequested(callBack: (reason: string) => void): Disposable;
+    onCancellationRequested(callBack: (reason?: string) => void): Disposable;
 }
 
 /**

--- a/packages/vscode-messenger/tests/messenger.test.ts
+++ b/packages/vscode-messenger/tests/messenger.test.ts
@@ -525,6 +525,22 @@ describe('Extension Messenger', () => {
         expect((cancel as any).listeners.length).toBe(0);
     });
 
+    test('Cancel request - no reason', async () => {
+        const messenger = new Messenger();
+        messenger.registerWebviewView(view1);
+        const cancel: CancellationTokenImpl = new CancellationTokenImpl();
+        setTimeout(() =>
+            cancel.cancel(), 300);
+        await messenger.sendRequest(simpleRequest, ViewParticipant(VIEW_TYPE_1), FORCE_HANDLER_TO_WAIT_PARAM, cancel)
+            .then(() => {
+                throw new Error('Expected to throw error');
+            }).catch((error) => {
+                expect(error.message).toBe('');
+            });
+        // check the internal cancelation listener attached in `sendRequestToWebview` was removed
+        expect((cancel as any).listeners.length).toBe(0);
+    });
+
     test('Handle cancel request', async () => {
         const messenger = new Messenger();
         messenger.registerWebviewView(view1);


### PR DESCRIPTION
Let clients conveniently cancel the token without any reason.

----

The cancellation works very nicely. Thanks for the great work, Dennis!

This PR proposes an API change to let clients `cancel` the token without a `reason`.

Before:
```jsx
useEffect(() => {
    const token = new CancellationTokenImpl();
    search(query, filter, token);
    return function () {
        token.cancel('');
    };
}, [search, filter, query]);
```

After:
```jsx
useEffect(() => {
    const token = new CancellationTokenImpl();
    search(query, filter, token);
    return function () {
        token.cancel();
    };
}, [search, filter, query]);
```