### PR TITLE
feat: declare acquireVsCodeApi on the global namespace

### DIFF
--- a/packages/vscode-messenger-webview/src/messenger.ts
+++ b/packages/vscode-messenger-webview/src/messenger.ts
@@ -19,7 +19,6 @@ import {
     isNotificationMessage, isRequestMessage, isResponseMessage, isWebviewIdMessageParticipant
 } from 'vscode-messenger-common';
 import type { VsCodeApi } from './vscode-api';
-import { acquireVsCodeApi } from './vscode-api';
 
 export class Messenger implements MessengerAPI {
 

--- a/packages/vscode-messenger-webview/src/vscode-api.ts
+++ b/packages/vscode-messenger-webview/src/vscode-api.ts
@@ -7,7 +7,9 @@
 /**
  * This API is provided by VS Code when the UI is loaded in a webview.
  */
-export declare function acquireVsCodeApi(): VsCodeApi;
+declare global {
+    function acquireVsCodeApi(): VsCodeApi;
+}
 
 export interface VsCodeApi {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
When using the bundled version of the `Messenger` class in `vscode-messenger-webview` (the one built in the `lib` directory), the code that gets imported is something like this:

vscode-api.js:
```javascript
Object.defineProperty(exports, "__esModule", { value: true });
```
(makes sense it's empty, since  `declare` and `interface` don't produce javascript code)

messenger.js:
```javascript
const vscode_api_1 = require("./vscode-api");
...
        this.vscode = vscode !== null && vscode !== void 0 ? vscode : (0, vscode_api_1.acquireVsCodeApi)();
```
(this is wrong: `acquireVsCodeApi` is defined on `globalThis`/`window`, not in the module!)

By moving the declaration of `acquireVsCodeApi` on the global namespace, the bundled code is now:
```
        this.vscode = vscode !== null && vscode !== void 0 ? vscode : acquireVsCodeApi();
```
(notice that there's no longer a reference to `vscode_api_1` or `./vscode-api`)